### PR TITLE
Add Svelte 101, Sapper Tutorial (Crash Course), eslint-plugin-svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Twitter](https://twitter.com/sveltejs)
 - [Discord](https://svelte.dev/chat)
 - [Reddit](https://www.reddit.com/r/sveltejs/)
-- [Japan Discord](https://discord.com/invite/YTXq3ZtBbx) - Svelte日本.
+- [Japan Discord](https://discord.com/invite/YTXq3ZtBbx) - Svelte 日本.
 
 ### Conferences
 
@@ -73,9 +73,11 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Develop a complete application with Svelte and TypeScript](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_getting_started) - MDN Web Docs.
 - [An Introduction to Actions](https://svelte.school/tutorials/introduction-to-actions) - Svelte School.
 - [Svelte Tutorial for Beginners](https://www.youtube.com/playlist?list=PL4cUxeGkcC9hlbrVO_2QFVqVPhlZmz7tO) - The Net Ninja (YouTube).
+- [Sapper Tutorial (Crash Course)](https://www.youtube.com/playlist?list=PL4cUxeGkcC9gdr4Qhx83gBBcID-KMe-PQ) - The Net Ninja (YouTube).
 - [SvelteJS Series - tutorials and talks](https://www.youtube.com/playlist?list=PLKUl5gVuvLjh7l0SDn-BoZtMgN3TDMNPd) - SpinSpire (YouTube).
 - [Svelte Stores](https://www.youtube.com/playlist?list=PLoKaNN3BjQX3fG-XOSwsPHtnV8FUY6lgK) - @lihautan (YouTube).
 - [Svelte Actions](https://www.youtube.com/playlist?list=PLoKaNN3BjQX3Gl14MBygFf8buPIw9pAeK) - @lihautan (YouTube).
+- [Svelte 101](https://www.youtube.com/hashtag/svelte101) - @lihautan (YouTube).
 - [Learn Svelte by building a habit tracker app](https://raddevon.com/articles/learn-svelte-by-building-a-habit-tracker-app/) - RadDevon.
 
 ### Studies
@@ -241,6 +243,7 @@ _Lint and format your code._
 - [eslint-plugin-svelte3](https://github.com/sveltejs/eslint-plugin-svelte3) - An ESLint plugin for components.
 - [prettier-plugin-svelte](https://github.com/sveltejs/prettier-plugin-svelte) - Format your components using prettier.
 - [svelte-check](https://www.npmjs.com/package/svelte-check) - Check your code.
+- [eslint-plugin-svelte](https://github.com/ota-meshi/eslint-plugin-svelte) - An ESLint plugin for Svelte using AST.
 
 ### Docs
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Twitter](https://twitter.com/sveltejs)
 - [Discord](https://svelte.dev/chat)
 - [Reddit](https://www.reddit.com/r/sveltejs/)
-- [Japan Discord](https://discord.com/invite/YTXq3ZtBbx) - Svelte 日本.
+- [Japan Discord](https://discord.com/invite/YTXq3ZtBbx) - Svelte日本.
 
 ### Conferences
 


### PR DESCRIPTION
I've added two YouTube Video Series (Svelte 101, Sapper Tutorial (Crash Course)) , and eslint-plugin-svelte.

Note:
Svelte 101 is  **No** YouTube playlist, so I've added hashtag link.