### PR TITLE
Add sveltekit-i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,9 +250,9 @@ _SSR framework._
 
 ### Internationalisation
 
-- [svelte-fluent](https://github.com/nubolab-ffwd/svelte-fluent) - Components for easy integration of [Fluent](https://projectfluent.org/) localization
-- [svelte-i18n](https://github.com/kaisermann/svelte-i18n) - For integrating [i18n](https://www.npmjs.com/package/i18n) style localization
-- [sveltekit-i18n](https://github.com/jarda-svoboda/sveltekit-i18n) - For integrating [i18n](https://www.npmjs.com/package/i18n) style localization
+- [svelte-fluent](https://github.com/nubolab-ffwd/svelte-fluent) - Components for easy integration of [Fluent](https://projectfluent.org/) localization.
+- [svelte-i18n](https://github.com/kaisermann/svelte-i18n) - Internationalization library for Svelte.
+- [sveltekit-i18n](https://github.com/jarda-svoboda/sveltekit-i18n) - For integrating [i18n](https://www.npmjs.com/package/i18n) style localization in SvelteKit.
 
 ## Routers
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ _SSR framework._
 ### Internationalisation
 
 - [svelte-fluent](https://github.com/nubolab-ffwd/svelte-fluent) - Components for easy integration of [Fluent](https://projectfluent.org/) localization
-- [svelte-i18n](https://github.com/kaisermann/svelte-i18n) - Store functions for integrating [i18n](https://www.npmjs.com/package/i18n) style localization
+- [svelte-i18n](https://github.com/kaisermann/svelte-i18n) - For integrating [i18n](https://www.npmjs.com/package/i18n) style localization
+- [sveltekit-i18n](https://github.com/jarda-svoboda/sveltekit-i18n) - For integrating [i18n](https://www.npmjs.com/package/i18n) style localization
 
 ## Routers
 


### PR DESCRIPTION
I ran into using svelte-i18n with SvelteKit, but it will not work. So it is useful to add the corresponding SvelteKit package as well.

Also the description "Store functions" is not right as the i18n package does not necessarily use stores.