### PR TITLE
Add svelte-frappe-charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ _Switch / on/off toggle / checkbox._
 ### Miscellaneous
 
 - [svelte-tree-viewer](https://github.com/kpulkit29/svelte-tree-viewer) - A lightweight component to render tree views.
+- [svelte-frappe-charts](https://github.com/himynameisdave/svelte-frappe-charts) - Svelte bindings for frappe-charts.
 
 ## Scaffold
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
   - [Calendar](#calendar)
   - [Maps](#maps)
   - [Form](#form)
+  - [Charts](#charts)
   - [Miscellaneous](#miscellaneous)
 - [Scaffold](#scaffold)
   - [Client](#client)
@@ -192,10 +193,13 @@ _Switch / on/off toggle / checkbox._
 - [svelte-checkbox](https://github.com/HosseinShabani/svelte-checkbox) - A checkbox component (cool animation, customizable).
 - [svelte-toggle](https://github.com/beyonk-adventures/svelte-toggle) - Basic toggle component with styling.
 
+### Charts
+
+- [svelte-frappe-charts](https://github.com/himynameisdave/svelte-frappe-charts) - Svelte bindings for frappe-charts.
+
 ### Miscellaneous
 
 - [svelte-tree-viewer](https://github.com/kpulkit29/svelte-tree-viewer) - A lightweight component to render tree views.
-- [svelte-frappe-charts](https://github.com/himynameisdave/svelte-frappe-charts) - Svelte bindings for frappe-charts.
 - [svelte-copyright](https://github.com/himynameisdave/svelte-copyright) - A Svelte component to format and display a copyright notice.
 
 ## Scaffold


### PR DESCRIPTION
Adds ﻿[`svelte-frappe-charts`](https://github.com/himynameisdave/svelte-frappe-charts).

Also: should we add a charts category? There are [other](https://www.npmjs.com/package/@carbon/charts-svelte) charting libraries for Svelte.