### PR TITLE
Add {@tolgee/svelte}

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ _SSR framework._
 
 - [svelte-fluent](https://github.com/nubolab-ffwd/svelte-fluent) - Components for easy integration of [Fluent](https://projectfluent.org/) localization
 - [svelte-i18n](https://github.com/kaisermann/svelte-i18n) - Store functions for integrating [i18n](https://www.npmjs.com/package/i18n) style localization
+- [@tolgee/svelte](https://github.com/tolgee/tolgee-js/tree/main/packages/svelte) - Web-based localization tool enabling users to translate directly in the Svelte app they develop.
 
 ## Routers
 


### PR DESCRIPTION
Add @tolgee/svelte to Miscellaneous - Internationalisation
With Tolgee for Svelte you can localize your Svelte app directly in-context of the app you are developing and manage all your translators in a single platform.