### PR TITLE
Add sveltekit-typescript-showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Learn Svelte by building a habit tracker app](https://raddevon.com/articles/learn-svelte-by-building-a-habit-tracker-app/) - RadDevon.
 - [Meet Svelte 3, a Powerful, Even Radical JavaScript Framework](https://www.sitepoint.com/svelte-javascript-framework-introduction/)  - SitePoint, by Chrome DevTools engineer @Jack_Franklin.
 - [Create your blog with SvelteKit](https://svelteland.github.io/svelte-kit-blog-demo/) - @zhuzilin (Github).
+- [Typescript + Svelte Cheatsheet](https://github.com/ivanhofer/sveltekit-typescript-showcase) - An overview of all TypeScript related topics for Svelte and SvelteKit - @ivanhofer (Github).
 
 ### Studies
 


### PR DESCRIPTION
Wasn't sure which category to place this. It's not really a `tutorial`, more like `unofficial documentation`, but that category does not yet exist. Feel free to move/edit as you see fit.

Anyways [this](https://github.com/ivanhofer/sveltekit-typescript-showcase) package is basically a high-quality documentation/reference of all the concepts that relate to `typescript` + `svelte` / `sveltekit`. Should be useful for any dev using `ts` in their `svelte` projects.