### PR TITLE
add svelte-domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ _UI frameworks for mobile._
 
 ## State Libraries
 - [Svelte-Domain](https://github.com/thegenius/svelte-domain) - The state management for svelte.
-- [svelte-asyncable](https://github.com/sveltetools/svelte-asyncable) - The Svelete store contract with support for asynchronous values
+- [svelte-asyncable](https://github.com/sveltetools/svelte-asyncable) - The Svelte store contract with support for asynchronous values.
 
 ## UI Libraries
 - [AgnosticUI](https://github.com/agnosticui/agnosticui) - Accessible Svelte Component Primitives (that also work with React, Vue 3, and Angular).

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ _For Single Page Applications (SPAs) and more._
 - [Elder.js](https://elderguide.com/tech/elderjs/) - Opinionated static site generator and web framework for Svelte built with SEO in mind.
 - [Routify](https://routify.dev/) - Routes for Svelte, automated by your file structure.
 - [JungleJS](https://www.junglejs.org/) - The Jamstack framework for Svelte with GraphQL.
+- [Svelte-Domain](https://github.com/thegenius/svelte-domain) - The state management for svelte.
 
 ## Dev Tools
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ _UI frameworks for mobile._
 
 ## State Libraries
 - [Svelte-Domain](https://github.com/thegenius/svelte-domain) - The state management for svelte.
+- [svelte-asyncable](https://github.com/sveltetools/svelte-asyncable) - The Svelete store contract with support for asynchronous values
 
 ## UI Libraries
 - [AgnosticUI](https://github.com/agnosticui/agnosticui) - Accessible Svelte Component Primitives (that also work with React, Vue 3, and Angular).

--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ _UI frameworks for mobile._
 - [Framework7](https://framework7.io/svelte/) - Full featured HTML framework for building iOS & Android apps.
 - [Capacitor](https://capacitorjs.com/solution/svelte) - Build native mobile apps with web technology and Svelte.
 
+## State Libraries
+- [Svelte-Domain](https://github.com/thegenius/svelte-domain) - The state management for svelte.
+
 ## UI Libraries
 - [AgnosticUI](https://github.com/agnosticui/agnosticui) - Accessible Svelte Component Primitives (that also work with React, Vue 3, and Angular).
 - [Sveltestrap](https://github.com/bestguy/sveltestrap) - Bootstrap 4 & 5 components.
@@ -269,7 +272,6 @@ _For Single Page Applications (SPAs) and more._
 - [Elder.js](https://elderguide.com/tech/elderjs/) - Opinionated static site generator and web framework for Svelte built with SEO in mind.
 - [Routify](https://routify.dev/) - Routes for Svelte, automated by your file structure.
 - [JungleJS](https://www.junglejs.org/) - The Jamstack framework for Svelte with GraphQL.
-- [Svelte-Domain](https://github.com/thegenius/svelte-domain) - The state management for svelte.
 
 ## Dev Tools
 


### PR DESCRIPTION
### svelte-domain is a library for svelte state management with following features:
1. Small: Zero dependencies and really small, only 1.26KB and gziped 624B
2. Clean: Only 2 API you should learn, createModel, createStore.
3. Support async: Naturally async support you will dream about after using writable.
4. Cool typescript support: You can enjoy all the good parts of typescript.
5. Elegant: clean concepts inspired by elm, dva, redux and rematch