### PR TITLE
fix changelog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [Official Guide](https://svelte.dev/tutorial)
 - [API Reference](https://svelte.dev/docs)
 - [GitHub Repo](https://github.com/sveltejs/svelte)
-- [Changelog](https://github.com/sveltejs/svelte/blob/master/CHANGELOG.md)
+- [Changelog](https://github.com/sveltejs/svelte/blob/master/packages/svelte/CHANGELOG.md)
 
 ### Community
 


### PR DESCRIPTION
The old link for sveltejs changelog is invalid.

So I fixed it.