### PR TITLE
Add SvelteKit-Adapter-Versioned-Worker into new PWA section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
   - [Animations](#animations)
   - [Form](#form-1)
   - [WebGL](#webgl)
+  - [PWA](#pwa)
   - [Portal](#portal)
   - [Fonts](#fonts)
   - [Internationalisation](#internationalisation)
@@ -254,6 +255,9 @@ _Templates / boilerplate / starter kits / stack ensemble / Yeoman generator._
 ### WebGL
 
 - [svelthree](https://github.com/vatro/svelthree) - Component library for declarative construction of reactive and reusable three.js scene graphs.
+
+### PWA
+- [SvelteKit-Adapter-Versioned-Worker](https://github.com/hedgehog125/SvelteKit-Adapter-Versioned-Worker) - An easy-to-use service worker build plugin where you don't need to worry about cache durations.
 
 ### Portal
 


### PR DESCRIPTION
Since service workers are quite complicated, I made a build plugin specifically for SvelteKit which generates them. Among other things it does to make things easy, it generates version files so you don't need to worry about cache durations.

This PR also adds a PWA section under the WebGL section as none of the existing ones seemed suitable. Alternatively, it could go in a new build plugin section.