### PR TITLE
Add daisyUI to UI Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ _UI frameworks for mobile._
 - [STDF](https://stdf.design) - Mobile web component library based on Svelte and Tailwind.
 - [M3 Svelte](https://github.com/KTibow/m3-svelte) - Robust component library implementing Material Design 3
 - [AgnosUI](https://amadeusitgroup.github.io/AgnosUI/latest/) - Highly configurable headless framework agnostic component library
+- [daisyUI](https://daisyui.com/) - The most popular component library for Tailwind CSS - `daisyUI` adds component class names to Tailwind CSS so you can make beautiful websites faster than ever.
 
 ## UI Components
 


### PR DESCRIPTION
As title says, added `daisyUI` to UI Libraries. The most popular component library for Tailwind CSS. `daisyUI` adds component class names to Tailwind CSS so you can make beautiful websites faster than ever. Here is the examples for the integrations:
- SvelteKit: https://stackblitz.com/edit/daisyui-sveltekit
- Svelte (Vite): https://stackblitz.com/edit/daisyui-svelte-vite