### PR TITLE
Add SVAR Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ _UI frameworks for mobile._
 - [M3 Svelte](https://github.com/KTibow/m3-svelte) - Robust component library implementing Material Design 3
 - [AgnosUI](https://amadeusitgroup.github.io/AgnosUI/latest/) - Highly configurable headless framework agnostic component library
 - [daisyUI](https://daisyui.com/) - The most popular component library for Tailwind CSS - `daisyUI` adds component class names to Tailwind CSS so you can make beautiful websites faster than ever.
+- [SVAR Core for Svelte](https://github.com/svar-widgets/core) - A collection of 20+ Svelte UI components for building fast-performing, interactive and responsive web apps.
 
 ## UI Components
 


### PR DESCRIPTION
SVAR Core is a set of ready-to-use Svelte UI components compatible with SvelteKit. Comes with detailed docs and demos. Please consider adding it to the list of Svelte UI libraries.