### PR TITLE
Add Lucide Svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ _Toaster / snackbar - Notify the user with a modeless temporary little popup._
 - [svelte-heroicons](https://github.com/krowten/svelte-heroicons) - Icons, crafted by the creators of Tailwind CSS.
 - [svelte-icomoon](https://github.com/aykutkardas/svelte-icomoon) - It makes it very simple to use SVG icons in your Svelte projects.
 - [svelte-unicons](https://github.com/devShamim/svelte-unicons) - Unicons svg icons for Svelte based on @iconscout/unicons.
+- [lucide-svelte](https://github.com/lucide-icons/lucide) - Implementation of the lucide icon library for svelte applications.
 
 ### Calendar
 


### PR DESCRIPTION
From https://lucide.dev/guide/packages/lucide-svelte

"Lucide is built with ES Modules, so it's completely tree-shakable.

Each icon can be imported as a Svelte component, which renders an inline SVG element. This way, only the icons that are imported into your project are included in the final bundle. The rest of the icons are tree-shaken away."