### PR TITLE
Add embedz

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ _Display non-editable events in a calendar._
 - [svelte-stepper](https://github.com/efstajas/svelte-stepper) - A Svelte component for building animated step flows.
 - [css-3d-progress](https://github.com/rofixro/css-3d-progress) - A 3D Progress Bar component
 - [svelte-speedometer](https://github.com/palerdot/svelte-speedometer) - Svelte component for showing speedometer like gauge using d3.
+- [embedz](https://github.com/embedz/embedz) - Easy, dependency free embeds for Svelte and Vue.
 
 ## Scaffold
 


### PR DESCRIPTION
Its a library I've been working on that allows you to import Embeds such as YouTube and Vimeo into svelte projects as components, Additionally it loads up to 5x faster than a regular YouTube iframe.