### PR TITLE
Add @nvl/sveltex

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ _Studies and research on the Svelte framework._
 - [modular-css](https://github.com/tivac/modular-css/tree/main/packages/svelte) - Preprocessor support for modular-css.
 - [svelte-preprocess-sass](https://github.com/ls-age/svelte-preprocess-sass) - Preprocessor for sass.
 - [svelte-preprocess-markdown](https://github.com/AlexxNB/svelte-preprocess-markdown) - Write Svelte components in markdown syntax.
+- [@nvl/sveltex](https://github.com/nvlang/sveltex) - Svelte + Markdown + LaTeX.
 
 ### Mobile
 


### PR DESCRIPTION
The project (which, full disclosure, is written by me) is different from the current markdown preprocessor options for Svelte (that I'm aware of) in the following main ways:

-   It adds support for transforming LaTeX code from your Svelte files into highly optimized SVGs with the help of your local TeX distribution.
-   It supports multiple markdown ecosystems, including unified (`rehype` + `remark`), `markdown-it`, and `marked`.
-   It has built-in support for multiple syntax highlighters (independently of which markdown ecosystem you're using): Shiki, `starry-night`, and highlight.js.
-   It has built-in support for both MathJax and KaTeX, and can deal with the CSS aspect of these for you.

**Project repository:** https://github.com/nvlang/sveltex
**Website / documentation:** https://sveltex.dev/