### PR TITLE
Add Quaff

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ _UI frameworks for mobile._
 - [AgnosticUI](https://github.com/agnosticui/agnosticui) - Accessible Svelte Component Primitives (that also work with React, Vue 3, and Angular).
 - [Svelte Animations](https://animation-svelte.vercel.app) - Consist of Svelte Magic UI, Svelte Aceternity UI, Svelte Luxe Components over 200+ Free Animation Components & 2 Templates 
 - [Svelte Marketing Blocks](https://sv-blocks.vercel.app) - A powerful library of 100+ marketing and UI blocks built using Shadcn Svelte, Tailwind CSS v4, and Svelte 5.
+- [Quaff](https://quaff.dev) - An extensive UI framework featuring modern and elegant components following Material Design 3 principles.
+
 ## UI Components
 
 ### Table


### PR DESCRIPTION
Add the new framework `Quaff` to the list of available Svelte UI libraries.

Quaff is a robust UI framework that features more than 20 already pre-styled components, a fully customisable layout, a dynamic color system and much more.
This library follows Material Design 3 principles to create a modern, elegant and coherent styling across entire applications.