### PR TITLE
Add svelte-streamdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ _Display non-editable events in a calendar._
 - [svelte-speedometer](https://github.com/palerdot/svelte-speedometer) - Svelte component for showing speedometer like gauge using d3.
 - [embedz](https://github.com/embedz/embedz) - Easy, dependency free embeds for Svelte and Vue.
 - [Edra](https://edra.tsuzat.com) - Best Rich Text Editor, made for Svelte Developers with Tiptap.
+- [svelte-streamdown](https://github.com/beynar/svelte-streamdown) - Port of [streamdown](https://streamdown.ai/). An all in one markdown renderer optimized for streaming with built in styles, math, mermaid, code highlighting support and more.
 
 ## Scaffold
 


### PR DESCRIPTION
Add [svelte-streamdown](https://github.com/beynar/svelte-streamdown). Port of the original streamdown. An all in one markdown renderer optimized for streaming with built in styles, math, mermaid, code highlighting support and more.

Demo site [here](https://svelte-streamdown.beynar.workers.dev)

✌️

