### PR TITLE
added notebook-app and new cool-stuff section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
     - [Charts](#charts)
     - [Miscellaneous](#miscellaneous)
   - [Scaffold](#scaffold)
+  - [Cool Stuff That Uses Svelte](#cool-stuff-that-uses-svelte)
   - [Utilities](#utilities)
     - [Animations](#animations)
     - [Drag \& Drop](#drag--drop)
@@ -260,6 +261,10 @@ _Templates / boilerplate / starter kits / stack ensemble / Yeoman generator._
 - [svelte-docs-starter](https://github.com/code-gio/svelte-docs-starter) - A modern documentation template built with Svelte 5, MDSvex, and Tailwind CSS.
 - [template-svelte](https://github.com/phaserjs/template-svelte) - An official quickstart template with Phaser.
 - [generic-app-template](https://github.com/GantonL/templates/tree/main/sveltekit-shadcn-v5) - A open-source modern full-stack web application template built with SvelteKit + shadcn-svelte. Supports i18n, theming, cookie managment, SEO management, static content with mdsvex, a shell component and more.
+
+## Cool Stuff That Uses Svelte
+
+- [notebook-app](https://github.com/datalisk/pulumi-aws-toolbox/tree/main/examples/notebook-app) - A open-source and serverless pastebin alternative built with Svelte, created with just ~100 lines of infrastructure code. It demonstrates how to easily run SvelteKit apps on AWS.
 
 ## Utilities
 


### PR DESCRIPTION
As requested in #145 I've created a new section and added the app there.

The app is an open-source and serverless pastebin alternative, created with just ~100 lines of infrastructure code.
It's a demo app on how to use pulumi-aws-toolbox, a library for deploying serverless web apps to the AWS cloud.

The UI of the app is built with SvelteKit and Tailwind. We're using AWS Lambda and S3 for the backend. So AWS cost should be almost $0. Meaning you can easily run your own pastebin alternative or use it as a starting point to deploy own apps to AWS.