### PR TITLE
Add retroui-svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ _UI frameworks for mobile._
 - [Svelte Animations](https://animation-svelte.vercel.app) - Consist of Svelte Magic UI, Svelte Aceternity UI, Svelte Luxe Components over 200+ Free Animation Components & 2 Templates
 - [Svelte Marketing Blocks](https://sv-blocks.vercel.app) - A powerful library of 100+ marketing and UI blocks built using Shadcn Svelte, Tailwind CSS v4, and Svelte 5.
 - [Quaff](https://quaff.dev) - An extensive UI framework featuring modern and elegant components following Material Design 3 principles.
+- [retroui-svelte](https://retroui-svelte.netlify.app) - A retro-styled component library for Svelte built on top of shadcn-svelte, offering 40+ customizable UI components for funky and playful interfaces.
 
 ## UI Components
 


### PR DESCRIPTION
### Why is this project awesome?

retroui-svelte brings a unique retro-themed design system to Svelte. 
It’s built on top of shadcn-svelte and includes 40+ customizable components (Button, Card, Input, Switch, etc.). 
Unlike most UI kits, retroui-svelte focuses on fun, playful, and nostalgic UIs while remaining fully themeable and easy to integrate.