### PR TITLE
Add svelte-aria-live – a simple svelte A11y live region manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ _Templates / boilerplate / starter kits / stack ensemble / Yeoman generator._
 
 ## Utilities
 
+### Accessibility
+
+- [svelte-aria-live](https://github.com/nickbrit/svelte-aria-live) - A lightweight package for seamless integration of WAI-ARIA live regions, improving accessibility for screen-reader users.
+
 ### Animations
 
 - [AutoAnimate](https://auto-animate.formkit.com/) - A zero-config, drop-in animation utility that adds smooth transitions to your Svelte app.


### PR DESCRIPTION
**Summary**

This PR adds `svelte-aria-live` under **Utilities → Accessibility**.

`svelte-aria-live` is tiny, headless accessibility toolkit for Svelte/SvelteKit: dual aria-live regions, imperative announce() API, screen-reader utility components, and a route-change helper.

**Why it’s awesome**

- Crucial Accessibility Feature (a11y): Fills a significant gap in the Svelte ecosystem for easily managing WAI-ARIA Live Regions.
- Simple and Idiomatic: Offers a minimal, Svelte-native approach to an otherwise complex accessibility requirement.
- Highly Focused: Dedicated solely to managing live region announcements cleanly.
- Open Source: Built and maintained for the community.

Link: https://github.com/nickbrit/svelte-aria-live