### PR TITLE
Add SvelteKit SaaS Starter to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ _Templates / boilerplate / starter kits / stack ensemble / Yeoman generator._
 - [svelte-docs-starter](https://github.com/code-gio/svelte-docs-starter) - A modern documentation template built with Svelte 5, MDSvex, and Tailwind CSS.
 - [template-svelte](https://github.com/phaserjs/template-svelte) - An official quickstart template with Phaser.
 - [generic-app-template](https://github.com/GantonL/templates/tree/main/sveltekit-shadcn-v5) - A open-source modern full-stack web application template built with SvelteKit + shadcn-svelte. Supports i18n, theming, cookie managment, SEO management, static content with mdsvex, a shell component and more.
+- [SvelteKit SaaS Starter](https://github.com/Signal-Lynx/sveltekit-saas-starter) - SvelteKit SaaS/LaaS starter for digital downloads and subscriptions, with Supabase Auth + Postgres, Stripe billing, entitlement gating, dashboards, and admin pages.
 
 ## Utilities
 


### PR DESCRIPTION
This project is awesome because it includes production-grade SaaS basics most starters skip (entitlement gating, admin ops pages, and clear security/customization docs) while staying approachable for solo builders.