### PR TITLE
Add oaysus to Scaffold section

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ _Templates / boilerplate / starter kits / stack ensemble / Yeoman generator._
 - [svelte-docs-starter](https://github.com/code-gio/svelte-docs-starter) - A modern documentation template built with Svelte 5, MDSvex, and Tailwind CSS.
 - [template-svelte](https://github.com/phaserjs/template-svelte) - An official quickstart template with Phaser.
 - [generic-app-template](https://github.com/GantonL/templates/tree/main/sveltekit-shadcn-v5) - A open-source modern full-stack web application template built with SvelteKit + shadcn-svelte. Supports i18n, theming, cookie managment, SEO management, static content with mdsvex, a shell component and more.
+- [oaysus](https://github.com/oaysus/cli) - Visual page builder for developer-built Svelte components. Push components with one CLI command, let marketing create pages visually.
 
 ## Utilities
 


### PR DESCRIPTION
## Summary

Adding [oaysus](https://github.com/oaysus/cli), a visual page builder that allows developers to build Svelte components and push them with a single CLI command, enabling marketing teams to create pages visually.

## Details

- **Name:** oaysus
- - **URL:** https://github.com/oaysus/cli
- - **Category:** Scaffold (Templates / boilerplate / starter kits)
- - **Framework Support:** React, Vue, Svelte
- - **License:** MIT
- - **Actively Maintained:** Yes