### PR TITLE
Add Heroshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ _For Single Page Applications (SPAs) and more._
 
 ## Dev Tools
 
+- [Heroshot](https://github.com/omachala/heroshot) - Screenshot automation CLI for documentation. Define screenshots once in config, regenerate all with one command using Playwright. Includes a SvelteKit integration.
+
 ### Adapters
 
 - [JesterKit EXE](https://github.com/Hugo-Dz/exe) - An adapter to distribute your SvelteKit web app as a single executable binary with zero runtime dependencies. Unlike static builds, it preserves all Kit features like SSR, API endpoints, server hooks, etc.


### PR DESCRIPTION
Adding [Heroshot](https://github.com/omachala/heroshot) to the Dev Tools section.

Heroshot is an open-source screenshot automation CLI for documentation. It uses Playwright to capture screenshots defined in config and includes a dedicated SvelteKit integration (`@heroshot/svelte`) for rendering components during capture.

**Why it's awesome:** Documentation screenshots go stale every time you change your UI. Heroshot lets you define them once and regenerate all with a single command — no more manual screenshots. It features a visual element picker (no CSS selectors needed), annotations, and framework integrations for SvelteKit, Next.js, Nuxt, and Vue.

- **GitHub:** https://github.com/omachala/heroshot
- **Website:** https://heroshot.sh