### PR TITLE
docs: add hugeicons to icon libraries section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ _Toaster / snackbar - Notify the user with a modeless temporary little popup._
 - [lucide-svelte](https://github.com/lucide-icons/lucide) - Implementation of the lucide icon library for svelte applications.
 - [svelte-icons-pack](https://github.com/leshak/svelte-icons-pack) - Based on <https://github.com/react-icons/react-icons>.
 - [svesome](https://github.com/pouchlabs/svesome) - A fontawesome v6 icons wrapper for svelte its awesome.
+- [hugeicons](https://github.com/hugeicons/svelte) - Beautiful, production-ready icon package for Svelte with complete icon coverage.
 - [moving icons](https://github.com/jis3r/icons) - A collection of beautifully crafted, animated Lucide icons.
 
 ### Calendar


### PR DESCRIPTION
### Add hugeicons to icon libraries section     
                                              
  Added hugeicons to the Icons section.       
  Hugeicons provides a beautiful,             
  production-ready icon package for Svelte    
  with complete icon coverage.                
                                              
  - Repository:                               
  https://github.com/hugeicons/svelte         
  - Installation: `npm i @hugeicons/svelte @hugeicons/core-free-icons`