### PR TITLE
add: annotaKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ _For Single Page Applications (SPAs) and more._
 
 ## Dev Tools
 
+- [annotaKit](https://github.com/nodestarQ/annotaKit) - Annotate your UI by clicking elements, selecting text, or multi-selecting, then export agent-ready context.
+
 ### Adapters
 
 - [JesterKit EXE](https://github.com/Hugo-Dz/exe) - An adapter to distribute your SvelteKit web app as a single executable binary with zero runtime dependencies. Unlike static builds, it preserves all Kit features like SSR, API endpoints, server hooks, etc.


### PR DESCRIPTION
annotaKit is a Svelte 5 component that adds a floating toolbar to SvelteKit apps for annotating UI elements. Click, select text, or multi-select, then export structured markdown that AI agents like Claude or Cursor can consume directly.

- npm: https://www.npmjs.com/package/annotakit
- Docs: https://annotakit.dev
- MIT licensed
