### PR TITLE
Add 'svelte-intlayer' into README localization tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ _Individual form components._
 - [@i18n-pro/svelte](https://github.com/i18n-pro/svelte) - Lightweight, simple, flexible, automatic translation internationalization tool for Svelte.
 - [ParaglideJS](https://inlang.com/m/dxnzrydw/library-inlang-paraglideJsAdapterSvelteKit) - Tiny, typesafe i18n library with translated links out of the box.
 - [wuchale](https://github.com/K1DV5/wuchale) - Internationalization library that lets you just write your code, no function calls or other ceremonies needed.
+- [svelte-intlayer](https://github.com/aymericzip/intlayer) - Per-component i18n focused on bundle size. Declarative + compiler based i18n.
 
 ## Routers
 


### PR DESCRIPTION
Intlayer is an i18n solution offering a per-component approach for svelte application where the bundle size matter 