### PR TITLE
Add mapmetrics-gl

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ _Display non-editable events in a calendar._
 - [leaflet-svelte](https://github.com/anoram/leaflet-svelte) - Svelte wrapper for Leaflet.
 - [esri-svelte](https://github.com/gavinr-maps/esri-svelte-example) - Web application that shows how to use the ArcGIS API for JavaScript with Svelte.
 - [svelte-maplibre](https://github.com/dimfeld/svelte-maplibre) - Svelte bindings for the MapLibre mapping library.
+- [mapmetrics-gl](https://github.com/MapMetrics/mapmetrics-gl) - Mapbox GL JS-compatible mapping library with built-in tiles, geocoding, routing, and search.
 
 ### Charts
 


### PR DESCRIPTION
Adding MapMetrics GL to the Maps section.

MapMetrics GL is a Mapbox GL JS-compatible mapping library with built-in support for map tiles, geocoding, routing, and search. Works with Svelte. EU-hosted, GDPR compliant.

GitHub: https://github.com/MapMetrics/mapmetrics-gl
Website: https://mapatlas.eu

Disclosure: I am affiliated with MapMetrics B.V.