### PR TITLE
Add svelte-audio-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ _UI frameworks for mobile._
 - [Svelte Marketing Blocks](https://sv-blocks.vercel.app) - A powerful library of 100+ marketing and UI blocks built using Shadcn Svelte, Tailwind CSS v4, and Svelte 5.
 - [Quaff](https://quaff.dev) - An extensive UI framework featuring modern and elegant components following Material Design 3 principles.
 - [retroui-svelte](https://retroui-svelte.netlify.app) - A retro-styled component library for Svelte built on top of shadcn-svelte, offering 40+ customizable UI components for funky and playful interfaces.
+- [svelte-audio-ui](https://svelte-audio-ui.vercel.app) - A set of accessible and composable Audio UI components. Built on top of shadcn-svelte, inspired by audio-ui, it's designed for you to copy, paste, and own.
 
 ## UI Components
 


### PR DESCRIPTION
Add [svelte-audio-ui](https://github.com/ddtamn/svelte-audio-ui) to the UI Libraries section.

A set of accessible and composable Audio UI components. Built on top of shadcn-svelte, inspired by audio-ui, it's designed for you to copy, paste, and own.

- Website: https://svelte.audio-ui.vercel.app
- License: MIT