### PR TITLE
Fix Svelte Native link

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ _Studies and research on the Svelte framework._
 
 _UI frameworks for mobile._
 
-- [Svelte Native](https://svelte-native.technology/) - Svelte controlling native components via Nativescript.
+- [Svelte Native](https://svelte.nativescript.org/) - Svelte controlling native components via Nativescript.
 - [Framework7](https://framework7.io/svelte/) - Full featured HTML framework for building iOS & Android apps.
 - [Capacitor](https://capacitorjs.com/solution/svelte) - Build native mobile apps with web technology and Svelte.
 


### PR DESCRIPTION
The Svelte Native link seems to have changed. The link that is currently on the README leads to the following page:

<img width="2558" height="1310" alt="image" src="https://github.com/user-attachments/assets/a54f1381-2b70-4630-9f52-d567a35fc545" />
