### PR TITLE
Add phantom-ui to UI Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ _Display non-editable events in a calendar._
 - [Edra](https://edra.tsuzat.com) - Best Rich Text Editor, made for Svelte Developers with Tiptap.
 - [svelte-streamdown](https://github.com/beynar/svelte-streamdown) - Port of [streamdown](https://streamdown.ai/). An all in one markdown renderer optimized for streaming with built in styles, math, mermaid, code highlighting support and more.
 - [svelte-bash](https://github.com/YusufCeng1z/svelte-bash) - A customizable terminal-style component for Svelte 5.
+- [phantom-ui](https://github.com/Aejkatappaja/phantom-ui) - Framework agnostic web component that generates skeleton loaders by measuring your real DOM, works with Svelte and SvelteKit.
 
 ## Scaffold
 


### PR DESCRIPTION
Adds phantom-ui under UI Components > Miscellaneous.

phantom-ui is a structure-aware skeleton loader. It wraps your real markup, measures each leaf element, and overlays shimmer placeholders at the same coordinates, so the skeleton matches the real layout with no separate skeleton component to maintain.

It is a framework agnostic web component built with Lit and works in Svelte and SvelteKit out of the box. Accessible by default with aria-busy, a configurable label, and prefers-reduced-motion support.