### PR TITLE
Add Slate - OLED-friendly Windows text editor (Svelte 5 + Tauri)

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,4 +416,6 @@ _Text editor plugins._
 ### Desktop
 
 - [Oxide-Lab](https://github.com/FerrisMind/oxide-lab) - Privacy-focused local LLM chat application built with Svelte 5 frontend and Rust backend using the `candle` ML framework.
+- [Slate](https://github.com/MiaAI-Lab/Slate) - A featherlight Windows markdown editor with OLED true-black theme, live preview, multi-tab support, and zero telemetry. Built with Svelte 5 and Tauri 2.
+- [Slate](https://github.com/MiaAI-Lab/Slate) - A featherlight Windows markdown editor with OLED true-black theme, live preview, multi-tab support, and zero telemetry. Built with Svelte 5 and Tauri 2.
 - [Zephyr](https://github.com/Prismo-Studio/Zephyr) - Open-source mod manager for PC games with built-in Archipelago multiworld randomizer support, built with Svelte 5 and Tauri 2.


### PR DESCRIPTION
Add [Slate](https://github.com/MiaAI-Lab/Slate) under Desktop applications.

Slate is a Windows text editor built with Svelte 5 + Tauri 2 + Rust:
- OLED true-black theme
- Local-first, zero telemetry
- Live GFM preview with split view
- Multi-tab editing