### PR TITLE
Add create-microservices-app to Scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ _Templates / boilerplate / starter kits / stack ensemble / Yeoman generator._
 
 - [create-vite](https://github.com/vitejs/vite/tree/main/packages/create-vite#readme) - Generates scaffold for a vite + svelte app.
 - [create-svelte](https://github.com/sveltejs/kit/tree/master/packages/create-svelte#readme) - A CLI for creating a new SvelteKit project.
+- [create-microservices-app](https://github.com/microservices-sh/microservices-sh/tree/main/packages/create-microservices-app) - Scaffold a Cloudflare-native SaaS app (Workers, D1, SvelteKit) with verified auth, booking, payment & email modules.
 - [saasstarter](https://github.com/CriticalMoments/CMSaasStarter) - A open source, fast, and free to host Svelte SaaS template.
 - [svelte-pwa-template](https://github.com/tretapey/svelte-pwa) - A starter template for PWAs based in the official Template. _(pre-v5)_
 - [vite-svelte-docker-template](https://github.com/bavragor/vite-svelte-docker-template) - Template for Svelte + Docker + Vite + Vitest.


### PR DESCRIPTION
Adds [create-microservices-app](https://github.com/microservices-sh/microservices-sh/tree/main/packages/create-microservices-app) to the Scaffold section.

It is an open-source `npm create` CLI that scaffolds a Cloudflare SvelteKit app (Workers + D1) with verified auth, booking, payment, and email modules. Published on npm. Placed near the existing create-svelte / create-vite entries.