### PR TITLE
Add JsonStudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,5 +415,6 @@ _Text editor plugins._
 
 ### Desktop
 
+- [JsonStudio](https://github.com/sundegan/JsonStudio) - Local-first desktop JSON workspace built with Svelte 5 and Tauri 2. [Website](https://jsonstudio.js.org/).
 - [Oxide-Lab](https://github.com/FerrisMind/oxide-lab) - Privacy-focused local LLM chat application built with Svelte 5 frontend and Rust backend using the `candle` ML framework.
 - [Zephyr](https://github.com/Prismo-Studio/Zephyr) - Open-source mod manager for PC games with built-in Archipelago multiworld randomizer support, built with Svelte 5 and Tauri 2.


### PR DESCRIPTION
Adds JsonStudio to the Desktop application examples section.

Project repository: https://github.com/sundegan/JsonStudio
Website: https://jsonstudio.js.org/

JsonStudio is a local-first desktop JSON workspace built with Svelte 5 and Tauri 2. It is useful as a Svelte example because it shows a practical production desktop app with real-world JSON editing, diffing, conversion, validation, and log extraction workflows.
