### PR TITLE
Add svelte-lightslide

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ _Display non-editable events in a calendar._
 - [Edra](https://edra.tsuzat.com) - Best Rich Text Editor, made for Svelte Developers with Tiptap.
 - [svelte-streamdown](https://github.com/beynar/svelte-streamdown) - Port of [streamdown](https://streamdown.ai/). An all in one markdown renderer optimized for streaming with built in styles, math, mermaid, code highlighting support and more.
 - [svelte-bash](https://github.com/YusufCeng1z/svelte-bash) - A customizable terminal-style component for Svelte 5.
+- [svelte-lightslide](https://github.com/mate2/svelte-lightslide) - A draggable, accessible image lightbox & gallery for Svelte 5 where the popup expands out of the clicked thumbnail and can be dragged around the page — a modern rebuild of Highslide.
 
 ## Scaffold
 


### PR DESCRIPTION
Adds svelte-lightslide, a Svelte 5 image lightbox & gallery. It's currently the only lightbox/gallery in the list, and it revives the Highslide pattern most modern lightboxes dropped: the popup expands out of the clicked thumbnail and can be dragged around the page (non-modal, multiple at once). Svelte 5 runes, zero runtime dependencies, accessible, with a live demo at https://svelte-lightslide.pages.dev.