### PR TITLE
Add @stitchapi/svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ _Individual form components._
 - [sswr](https://github.com/ConsoleTVs/sswr) - Svelte stale while revalidate (SWR) data fetching strategy.
 - [svelte-query](https://sveltequery.vercel.app/) - Fetch, cache and update data in your Svelte applications all without touching any "global state".
 - [tanstack-svelte-query](https://tanstack.com/query/latest/docs/svelte/overview) - Framework agnostic type-safe query and mutation library for Svelte.
+- [@stitchapi/svelte](https://github.com/rejifald/StitchAPI/tree/main/packages/svelte) - Streaming-first StitchAPI bindings: typed, validated `stitchStore` / `stitchStreamStore` Svelte stores that re-render as response deltas arrive.
 
 ### Sound & Video
 


### PR DESCRIPTION
Adds `@stitchapi/svelte` under **Utilities → HTTP Requests**, alongside the other data-fetching entries.

**What it is:** typed, validated Svelte stores (`stitchStore` / `stitchStreamStore`) over a single [StitchAPI](https://stitchapi.dev) definition — real `{ subscribe }` stores, so no custom reactivity. The run starts on the first subscriber and is aborted on teardown.

**What makes it different from the neighbours:** it's streaming-first — `stitchStreamStore` emits a new store value as each response *delta* arrives (SSE / chunked streams), so the UI re-renders incrementally rather than only on the final response. Works on **Svelte 4 and 5**, with an optional TanStack Query `queryOptions` helper for callers who want it.

- Source: https://github.com/rejifald/StitchAPI/tree/main/packages/svelte
- npm: https://www.npmjs.com/package/@stitchapi/svelte

Format: description starts with an uppercase character and ends with a period; placed in the most appropriate existing field; commit message follows `Add {project name}`.
