### PR TITLE
Add Product Plate

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ _Templates / boilerplate / starter kits / stack ensemble / Yeoman generator._
 - [create-vite](https://github.com/vitejs/vite/tree/main/packages/create-vite#readme) - Generates scaffold for a vite + svelte app.
 - [create-svelte](https://github.com/sveltejs/kit/tree/master/packages/create-svelte#readme) - A CLI for creating a new SvelteKit project.
 - [saasstarter](https://github.com/CriticalMoments/CMSaasStarter) - A open source, fast, and free to host Svelte SaaS template.
+- [Product Plate](https://github.com/rodrgds/productplate) - An open-source SvelteKit + Convex starter for building SaaS products.
 - [svelte-pwa-template](https://github.com/tretapey/svelte-pwa) - A starter template for PWAs based in the official Template. _(pre-v5)_
 - [vite-svelte-docker-template](https://github.com/bavragor/vite-svelte-docker-template) - Template for Svelte + Docker + Vite + Vitest.
 - [svelte-docs-starter](https://github.com/code-gio/svelte-docs-starter) - A modern documentation template built with Svelte 5, MDSvex, and Tailwind CSS.


### PR DESCRIPTION
## Add Product Plate

This adds Product Plate to the Scaffold section.

It's an open-source SvelteKit + Convex starter for building products (originally built for a hackathon but now really good for any sort of SaaS). It comes with auth, billing, realtime data, AI integrations, product UI, tests, deployment setup and a good SEO and landing page components setup.
