### PR TITLE
Add Recipe Jar to Application Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
       - [JetBrains](#jetbrains)
   - [Application Examples](#application-examples)
     - [Desktop](#desktop)
+    - [Web](#web)
 
 ## Resources
 
@@ -417,3 +418,7 @@ _Text editor plugins._
 
 - [Oxide-Lab](https://github.com/FerrisMind/oxide-lab) - Privacy-focused local LLM chat application built with Svelte 5 frontend and Rust backend using the `candle` ML framework.
 - [Zephyr](https://github.com/Prismo-Studio/Zephyr) - Open-source mod manager for PC games with built-in Archipelago multiworld randomizer support, built with Svelte 5 and Tauri 2.
+
+### Web
+
+- [Recipe Jar](https://recipejar.app) - Local-first recipe keeper built with Svelte 5 runes and IndexedDB: paste a link, get a clean card, save unlimited recipes offline with no backend. [Open source](https://github.com/sbmagar13/recipe-jar).


### PR DESCRIPTION
Adds Recipe Jar, an open-source recipe keeper built with Svelte 5 (runes) and Vite.

Application Examples only had a Desktop subsection, so I added a Web one and placed Recipe Jar there. Why it's a useful Svelte example: it's a real, shipped app that leans entirely on Svelte 5 runes plus IndexedDB with no backend and no state library, holds under a 70KB gzipped budget enforced in CI, and works offline as an installable PWA.

- Live: https://recipejar.app
- Source (MIT): https://github.com/sbmagar13/recipe-jar

Entry follows the format in CONTRIBUTING (uppercase start, period end). Thanks for maintaining the list!
