### PR TITLE
Add reflow to Svelte resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,8 @@ _Individual form components._
 - [ParaglideJS](https://inlang.com/m/dxnzrydw/library-inlang-paraglideJsAdapterSvelteKit) - Tiny, typesafe i18n library with translated links out of the box.
 - [wuchale](https://github.com/K1DV5/wuchale) - Internationalization library that lets you just write your code, no function calls or other ceremonies needed.
 
+- [reflow](https://github.com/valtors/reflow) - SSR-safe responsive toolkit for TypeScript. Breakpoints, container queries, fluid typography, and user preference hooks across 8 frameworks.
+
 ## Routers
 
 _For Single Page Applications (SPAs) and more._


### PR DESCRIPTION
## What

Adding [reflow](https://github.com/valtors/reflow) to the list.

## Why

Reflow provides Svelte stores for responsive design: media queries, breakpoints, viewport tracking, container queries, fluid typography, and user preferences. SSR-safe, zero runtime deps, fully typed.

NPM: [reflow](https://www.npmjs.com/package/reflow)