### PR TITLE
Add Sanwo to Integrations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ _UI frameworks for mobile._
 - [Svelte Native](https://svelte-native.technology/) - Svelte controlling native components via Nativescript.
 - [Framework7](https://framework7.io/svelte/) - Full featured HTML framework for building iOS & Android apps.
 - [Capacitor](https://capacitorjs.com/solution/svelte) - Build native mobile apps with web technology and Svelte.
+- [Sanwo](https://github.com/Sanwohq/core) - Universal payment SDK for Svelte. One interface for Paystack, Flutterwave, Razorpay, Monnify, Interswitch, and custom providers. Context + stores. Works with SvelteKit.
 
 ## State Libraries
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ _UI frameworks for mobile._
 - [Svelte Native](https://svelte-native.technology/) - Svelte controlling native components via Nativescript.
 - [Framework7](https://framework7.io/svelte/) - Full featured HTML framework for building iOS & Android apps.
 - [Capacitor](https://capacitorjs.com/solution/svelte) - Build native mobile apps with web technology and Svelte.
-- [Sanwo](https://github.com/Sanwohq/core) - Universal payment SDK for Svelte. One interface for Paystack, Flutterwave, Razorpay, Monnify, Interswitch, and custom providers. Context + stores. Works with SvelteKit.
+- [Sanwo](https://github.com/Sanwohq) - Universal payment SDK for Svelte. One interface for Paystack, Flutterwave, Razorpay, Monnify, Interswitch, and custom providers. Context + stores. Works with SvelteKit.
 
 ## State Libraries
 


### PR DESCRIPTION
Adds [Sanwo](https://github.com/Sanwohq/core) (`@sanwohq/svelte`) to the Integrations section.

Sanwo is an open-source universal payment SDK. The Svelte package provides context + stores for integrating Paystack, Flutterwave, Razorpay, Monnify, Interswitch, and custom providers through one API. Works with SvelteKit.

- **npm:** https://www.npmjs.com/package/@sanwohq/svelte
- **Docs:** https://docs.sanwo.dev
- **License:** Apache-2.0