### PR TITLE
Add human-kit to UI Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ _UI frameworks for mobile._
 - [retroui-svelte](https://retroui-svelte.netlify.app) - A retro-styled component library for Svelte built on top of shadcn-svelte, offering 40+ customizable UI components for funky and playful interfaces.
 - [svelte-audio-ui](https://svelte-audio-ui.vercel.app) - A set of accessible and composable Audio UI components. Built on top of shadcn-svelte, inspired by audio-ui, it's designed for you to copy, paste, and own.
 - [AgentsKit](https://github.com/AgentsKit-io/agentskit) - Headless chat and agent components plus a store for building AI apps in Svelte, with a framework-agnostic core supporting streaming, tools, memory and RAG.
+- [human-kit](https://ui.human-kit.com) - Headless, accessible UI primitives for Svelte 5 - ARIA semantics, keyboard interaction and focus management included, styling left entirely to you.
 
 ## UI Components
 


### PR DESCRIPTION
Adds [`@human-kit/ui`](https://ui.human-kit.com) to the UI Libraries section.

Headless, accessible UI primitives for Svelte 5 — the components ship behavior, ARIA semantics, keyboard interaction and focus management, and leave every pixel to the consumer. Closest neighbours already on the list are Melt UI and AgnosticUI.

- Docs and live demos: https://ui.human-kit.com
- Source: https://github.com/human-kit/ui
- npm: https://www.npmjs.com/package/@human-kit/ui
- MIT licensed, Svelte `^5` peer dependency, one runtime dependency (`@floating-ui/dom`, only where things float)
- 26 components — Dialog, Drawer, ComboBox, DatePicker/DateRangePicker, Menu, Table, Tree, TransferList and more — each with an accessibility contract covered by tests

Full disclosure: I'm the author. Currently published as `1.0.0-beta.x`; the public API is close to settled. Happy to hold this until 1.0 if the list prefers stable releases only — just say the word.