### PR TITLE
Add crd-ui under UI Components > Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ _Display non-editable events in a calendar._
 - [Edra](https://edra.tsuzat.com) - Best Rich Text Editor, made for Svelte Developers with Tiptap.
 - [svelte-streamdown](https://github.com/beynar/svelte-streamdown) - Port of [streamdown](https://streamdown.ai/). An all in one markdown renderer optimized for streaming with built in styles, math, mermaid, code highlighting support and more.
 - [svelte-bash](https://github.com/YusufCeng1z/svelte-bash) - A customizable terminal-style component for Svelte 5.
+- [crd-ui](https://github.com/JuandaGarcia/crd-ui) - Credit and debit card visualization for payment forms and saved-card views, with live brand detection and a 3D flip.
 
 ## Scaffold
 


### PR DESCRIPTION
Adds [crd-ui](https://github.com/JuandaGarcia/crd-ui) under **UI Components → Miscellaneous**.

A credit and debit card visualization for payment forms and saved-card views: live brand detection while typing, formatting and masking, and a 3D flip when the CVC is focused.

- Docs and live playground: https://crd-ui.juanda.co
- npm: `crd-ui` — the Svelte 5 component is the `crd-ui/svelte` subpath
- Zero runtime dependencies, MIT, TypeScript types included

Display-only by design: it never handles or stores real card data — you wire it to your own inputs.