### PR TITLE
Add microfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ _Templates / boilerplate / starter kits / stack ensemble / Yeoman generator._
 - [svelte-docs-starter](https://github.com/code-gio/svelte-docs-starter) - A modern documentation template built with Svelte 5, MDSvex, and Tailwind CSS.
 - [template-svelte](https://github.com/phaserjs/template-svelte) - An official quickstart template with Phaser.
 - [generic-app-template](https://github.com/GantonL/templates/tree/main/sveltekit-shadcn-v5) - A open-source modern full-stack web application template built with SvelteKit + shadcn-svelte. Supports i18n, theming, cookie managment, SEO management, static content with mdsvex, a shell component and more.
+- [microfolio](https://github.com/aker-dev/microfolio) - A static portfolio generator for creatives built with SvelteKit and Tailwind CSS 4, where content is just folders and Markdown files instead of a database, with interactive maps, EXIF metadata extraction and no tracking.
 
 ## Utilities
 


### PR DESCRIPTION
microfolio is a static portfolio generator for creatives — designers, artists, architects — built with SvelteKit 2, Svelte 5 and Tailwind CSS 4.

It fills a gap in the Scaffold section: it is the only entry aimed at portfolio sites, and it takes a file-based approach where the whole content is folders and Markdown files, with no database and no CMS to run. It ships interactive maps (MapLibre GL + OpenStreetMap), EXIF/IPTC metadata extraction, WebP optimisation at build time, grid/list/map view modes with shareable URLs, and i18n via svelte-i18n. It is privacy-first by construction: no cookies, no analytics, no tracking.

It just reached 1.0, which freezes the content structure and configuration keys for the whole 1.x cycle. MIT licensed. Demo: https://aker-dev.github.io/microfolio/
