### PR TITLE
Add Iconotype

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,5 +415,6 @@ _Text editor plugins._
 
 ### Desktop
 
+- [Iconotype](https://github.com/iconotype/iconotype) - Icon font toolkit built with Svelte 5 and Tauri 2, sharing one Svelte core between a desktop app, a web app and a VS Code webview.
 - [Oxide-Lab](https://github.com/FerrisMind/oxide-lab) - Privacy-focused local LLM chat application built with Svelte 5 frontend and Rust backend using the `candle` ML framework.
 - [Zephyr](https://github.com/Prismo-Studio/Zephyr) - Open-source mod manager for PC games with built-in Archipelago multiworld randomizer support, built with Svelte 5 and Tauri 2.


### PR DESCRIPTION
Adds [Iconotype](https://github.com/iconotype/iconotype) under Application Examples → Desktop, alphabetically before Oxide-Lab.

It is an icon font toolkit — import SVGs or an IcoMoon project, normalize the geometry a font needs, export woff2 and CSS. What makes it a reasonable Svelte example: one Svelte 5 core (runes throughout) serves three shells — a Tauri 2 desktop app, a web app using OPFS, and a VS Code webview — with the host filesystem behind a single interface, so no component knows which it is running in.

MIT, and the fonts are built locally: nothing is uploaded anywhere.

Followed CONTRIBUTING.md: description starts uppercase, ends with a period, and the commit is `Add Iconotype`.