### PR TITLE
Add Inko to UI Components > Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ _Display non-editable events in a calendar._
 - [Edra](https://edra.tsuzat.com) - Best Rich Text Editor, made for Svelte Developers with Tiptap.
 - [svelte-streamdown](https://github.com/beynar/svelte-streamdown) - Port of [streamdown](https://streamdown.ai/). An all in one markdown renderer optimized for streaming with built in styles, math, mermaid, code highlighting support and more.
 - [svelte-bash](https://github.com/YusufCeng1z/svelte-bash) - A customizable terminal-style component for Svelte 5.
+- [Inko](https://github.com/sinabin/inko-sdk) - Self-hosted PDF annotation SDK built with Svelte 5, consumed as a framework-agnostic embed.
 
 ## Scaffold
 


### PR DESCRIPTION
Adds Inko, an Apache-2.0 self-hosted PDF annotation SDK built on PDF.js.

It differs from the PDF entries already listed: instead of writing annotations
into the PDF, it returns editing state as a separate serializable value the host
application stores, which allows several reviewers' markup to be overlaid and
editing to resume from a selected state.

- Repo: https://github.com/sinabin/inko-sdk
- npm: https://www.npmjs.com/package/inko-pdf-sdk
- License: Apache-2.0
- Docs: README, integration guide, architecture and data-flow docs in-repo
- Tests: 613 unit tests, 44 browser E2E specs, a 120-page performance gate, and
  coverage thresholds, all enforced in CI

Checked for duplicates; no existing entry for this project.

Note on scope: Inko is built with Svelte 5 but is consumed as a framework-agnostic
iframe SDK rather than as a Svelte component. I am proposing it under Miscellaneous
alongside EmbedPDF; if that falls outside the list's scope, feel free to close.