### PR TITLE
Add Poveste

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ _For Single Page Applications (SPAs) and more._
 ## Dev Tools
 
 - [Frontman](https://github.com/frontman-ai/frontman) - Open-source AI coding agent that lives in your browser with click-to-edit and hot reload for Svelte apps.
+- [Poveste](https://github.com/poveste-dev/poveste) - Component playgrounds for Svelte 5 and SvelteKit, powered by Vite. A drop-in fork of histoire.
 
 ### Adapters
 


### PR DESCRIPTION
Adds [Poveste](https://github.com/poveste-dev/poveste) to **Dev Tools**.

Poveste builds a browsable book of stories from your components, powered by Vite — a variant grid, a controls panel, the generated source for whatever state you are looking at, and accessibility checks. It is a drop-in fork of [histoire](https://github.com/histoire-dev/histoire), so existing stories and config work unchanged.

**Why it is worth listing for Svelte in particular.** histoire supported Svelte, but its controls panel was empty for every Svelte story — `autoPropsDisabled` sat on the API implying otherwise, and the gap had been open since 2022. Poveste closes it: the panel is built from a component's declared props, read through Svelte's own compiler AST, with no binding and no `initState` required. Svelte 5 and SvelteKit each have a full example book, and both run the same shared conformance suite as the Vue and Nuxt books rather than a reduced one.

MIT, actively developed, 0.12.3 on npm.
