### PR TITLE
Add PR Cockpit

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,3 +417,4 @@ _Text editor plugins._
 
 - [Oxide-Lab](https://github.com/FerrisMind/oxide-lab) - Privacy-focused local LLM chat application built with Svelte 5 frontend and Rust backend using the `candle` ML framework.
 - [Zephyr](https://github.com/Prismo-Studio/Zephyr) - Open-source mod manager for PC games with built-in Archipelago multiworld randomizer support, built with Svelte 5 and Tauri 2.
+- [PR Cockpit](https://github.com/theolundqvist/pr-cockpit) - An extremely fast GitHub for reviewing pull requests: PRs open in about 20 ms. Keyboard-first, with a CLI for coding agents. Svelte 5 runes UI over a Bun server.


### PR DESCRIPTION
PR Cockpit is an extremely fast GitHub for reviewing pull requests: a PR opens in about 20 ms where github.com takes about 1.4 s (p50, [docs/BENCHMARKS.md](https://github.com/theolundqvist/pr-cockpit/blob/main/docs/BENCHMARKS.md)), it is keyboard-first, and it ships a CLI that coding agents use to read PRs and wait for changes.

I think it is awesome for this list because the whole review UI is Svelte 5 with runes for state, served by a Bun server, so it shows Svelte driving a dense keyboard-driven desktop interface (diffs, threads, checks) fast enough to replace the website.

It fits Application Examples -> Desktop alongside the existing Svelte desktop apps there: https://github.com/theolundqvist/pr-cockpit and https://prcockpit.com
