### PR TITLE
Add dockview-svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ _UI frameworks for mobile._
 - [svelte-audio-ui](https://svelte-audio-ui.vercel.app) - A set of accessible and composable Audio UI components. Built on top of shadcn-svelte, inspired by audio-ui, it's designed for you to copy, paste, and own.
 - [AgentsKit](https://github.com/AgentsKit-io/agentskit) - Headless chat and agent components plus a store for building AI apps in Svelte, with a framework-agnostic core supporting streaming, tools, memory and RAG.
 - [human-kit](https://ui.human-kit.com) - Headless, accessible UI primitives for Svelte 5 - ARIA semantics, keyboard interaction and focus management included, styling left entirely to you.
+- [dockview-svelte](https://github.com/eddow/dockview-svelte) - Svelte 5 wrapper around the Dockview layout engine — docking panels, tab groups, drag-and-drop, floating groups, popouts, and serialization, with a Svelte-native API.
 
 ## UI Components
 


### PR DESCRIPTION
It seemed to me like a basic (it's done for all frameworks *but* svelte) so I was surprised it was not ported yet.
I wished it was, so I did.