### PR TITLE
Add Bardkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ _Display non-editable events in a calendar._
 - [svelte-streamdown](https://github.com/beynar/svelte-streamdown) - Port of [streamdown](https://streamdown.ai/). An all in one markdown renderer optimized for streaming with built in styles, math, mermaid, code highlighting support and more.
 - [svelte-bash](https://github.com/YusufCeng1z/svelte-bash) - A customizable terminal-style component for Svelte 5.
 - [crd-ui](https://github.com/JuandaGarcia/crd-ui) - Credit and debit card visualization for payment forms and saved-card views, with live brand detection and a 3D flip.
+- [Bardkit](https://github.com/darkdarkcocoa/bardkit) - A playable instrument HUD for in-game music, with a sample-free Web Audio synth and 22 keys captured from the host app.
 
 ## Scaffold
 


### PR DESCRIPTION
Adds [Bardkit](https://github.com/darkdarkcocoa/bardkit) under UI Components > Miscellaneous.

It is a Svelte 5 keyboard HUD that lets players perform music inside a multiplayer game. What makes it different from a normal UI component is that it has to coexist with a host application that also wants the keyboard: while open it listens on `window` in the capture phase and stops propagation for its 22 keys and Escape, so the game's movement handler never sees them, and a `claimKey` prop lets the host take back any key it still needs. Visibility is a prop rather than a store, because in a game the server decides when a performance actually starts.

The notes are synthesized with the Web Audio API rather than sampled, and the audio core is a separate framework-free package, so the panel is replaceable.

Playable demo, no install: https://darkdarkcocoa.github.io/bardkit/

Svelte 5, no dependencies beyond svelte. MIT OR Apache-2.0.